### PR TITLE
Update ElasticSearch Client to Version 8.17

### DIFF
--- a/hcx-apis/pom.xml
+++ b/hcx-apis/pom.xml
@@ -107,17 +107,6 @@
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-data-elasticsearch</artifactId>
-			<exclusions>
-				<exclusion>
-					<groupId>org.springframework.data</groupId>
-					<artifactId>spring-data-elasticsearch</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<dependency>
-			<groupId>org.springframework.data</groupId>
-			<artifactId>spring-data-elasticsearch</artifactId>
-			<version>4.2.5</version>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
@@ -180,6 +169,11 @@
 			<artifactId>bcpkix-jdk15on</artifactId>
 			<version>1.70</version>
 			<scope>compile</scope>
+		</dependency>
+		<dependency>
+			<groupId>co.elastic.clients</groupId>
+			<artifactId>elasticsearch-java</artifactId>
+			<version>8.17.0</version>
 		</dependency>
 	</dependencies>
 

--- a/hcx-apis/src/main/java/org/swasth/hcx/config/ElasticSearchConfiguration.java
+++ b/hcx-apis/src/main/java/org/swasth/hcx/config/ElasticSearchConfiguration.java
@@ -1,22 +1,19 @@
 package org.swasth.hcx.config;
 
-
-
-import org.elasticsearch.client.RestHighLevelClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.transport.rest_client.RestClientTransport;
+import co.elastic.clients.json.jackson.JacksonJsonpMapper;
+import org.apache.http.HttpHost;
+import org.elasticsearch.client.RestClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.data.elasticsearch.client.ClientConfiguration;
-import org.springframework.data.elasticsearch.client.RestClients;
-import org.springframework.data.elasticsearch.config.AbstractElasticsearchConfiguration;
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 import org.swasth.auditindexer.utils.ElasticSearchUtil;
 
 @Configuration
 @EnableElasticsearchRepositories(basePackages = "org.swasth.hcx.repository")
-//@ComponentScan(basePackages = {"org.swasth.hcx"})
-public class ElasticSearchConfiguration extends AbstractElasticsearchConfiguration {
+public class ElasticSearchConfiguration {
 
     @Value("${es.host:localhost}")
     public String esHost;
@@ -25,16 +22,15 @@ public class ElasticSearchConfiguration extends AbstractElasticsearchConfigurati
     public int esPort;
 
     @Bean
-    @Override
-    public RestHighLevelClient elasticsearchClient() {
-        final ClientConfiguration config = ClientConfiguration.builder()
-                .connectedTo(esHost + ":" + esPort)
-                .build();
-
-        return RestClients.create(config).rest();
+    public ElasticsearchClient elasticsearchClient() {
+        RestClient restClient = RestClient.builder(new HttpHost(esHost, esPort)).build();
+        RestClientTransport transport = new RestClientTransport(restClient, new JacksonJsonpMapper());
+        return new ElasticsearchClient(transport);
     }
+
     @Bean
     public ElasticSearchUtil elasticSearchUtil() throws Exception {
-        return new ElasticSearchUtil(esHost,esPort);
+        return new ElasticSearchUtil(esHost, esPort);
     }
 }
+

--- a/hcx-apis/src/main/java/org/swasth/hcx/service/AuditService.java
+++ b/hcx-apis/src/main/java/org/swasth/hcx/service/AuditService.java
@@ -1,9 +1,9 @@
 package org.swasth.hcx.service;
 
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.RestHighLevelClient;
-import org.elasticsearch.search.SearchHit;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchResponse;
+import co.elastic.clients.elasticsearch.core.search.Hit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -12,7 +12,6 @@ import org.swasth.common.dto.AuditSearchRequest;
 import org.swasth.common.utils.JSONUtils;
 import org.swasth.hcx.utils.SearchUtil;
 
-import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -24,38 +23,30 @@ public class AuditService {
     private static final Logger logger = LoggerFactory.getLogger(AuditService.class);
 
     @Autowired
-    private RestHighLevelClient client;
+    private ElasticsearchClient esClient;
 
-    /**
-     * Used to search for audit events based on data provided in the {@link AuditSearchRequest} DTO. For more info take a look
-     * at DTO javadoc.
-     *
-     * @param request DTO containing info about what to search for.
-     * @return Returns a list of found audit events.
-     */
     public List<Map<String, Object>> search(final AuditSearchRequest request, String action, String index) {
         try {
             logger.info("Audit search started: {}", JSONUtils.serialize(request));
             request.setAction(action);
-            final SearchRequest searchRequest = SearchUtil.buildSearchRequest(
-                    index,
-                    request
-            );
 
+            SearchRequest searchRequest = SearchUtil.buildSearchRequest(index, request);
             return searchInternal(searchRequest);
+
         } catch (Exception e) {
-            logger.error("Error while processing audit search :: message: {} :: trace: {}", e.getMessage(), e.getStackTrace());
+            logger.error("Error while processing audit search :: message: {}", e.getMessage(), e);
             return Collections.emptyList();
         }
     }
 
+    private List<Map<String, Object>> searchInternal(final SearchRequest request) throws Exception {
+        SearchResponse<Map<String, Object>> response = esClient.search(request, (Class<Map<String, Object>>)(Class<?>) Map.class);
 
-    private List<Map<String,Object>> searchInternal(final SearchRequest request) throws IOException {
-        final SearchHit[] searchHits = client.search(request, RequestOptions.DEFAULT).getHits().getHits();
-        final List<Map<String, Object>> audit = new ArrayList<>(searchHits.length);
-        for (SearchHit hit : searchHits) {
-            audit.add(hit.getSourceAsMap());
+        List<Map<String, Object>> audit = new ArrayList<>();
+        for (Hit<Map<String, Object>> hit : response.hits().hits()) {
+            audit.add(hit.source());
         }
+
         logger.info("Audit search completed :: count: {}", audit.size());
         return audit;
     }

--- a/hcx-apis/src/main/java/org/swasth/hcx/utils/SearchUtil.java
+++ b/hcx-apis/src/main/java/org/swasth/hcx/utils/SearchUtil.java
@@ -1,34 +1,30 @@
 package org.swasth.hcx.utils;
 
-import org.elasticsearch.action.search.SearchRequest;
-import org.elasticsearch.index.query.BoolQueryBuilder;
-import org.elasticsearch.index.query.QueryBuilder;
-import org.elasticsearch.index.query.QueryBuilders;
-import org.elasticsearch.search.builder.SearchSourceBuilder;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
+import co.elastic.clients.elasticsearch._types.query_dsl.Query;
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
 import org.springframework.util.CollectionUtils;
 import org.swasth.common.dto.AuditSearchRequest;
 import org.swasth.common.utils.Constants;
+import co.elastic.clients.json.JsonData;
 
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Optional;
 
 public final class SearchUtil {
 
     public static SearchRequest buildSearchRequest(final String indexName,
-                                                   final AuditSearchRequest request) {
-    	try {
+            final AuditSearchRequest request) {
+        try {
             final int page = request.getOffset();
             final int size = request.getLimit();
             final int from = page <= 0 ? 0 : page * size;
 
-            SearchSourceBuilder builder = new SearchSourceBuilder()
-                    .from(from)
-                    .size(size)
-                    .postFilter(getQueryBuilder(request));
-
-            final SearchRequest searchRequest = new SearchRequest(indexName);
-            searchRequest.source(builder);
+            SearchRequest searchRequest = SearchRequest.of(s -> s.index(indexName)
+                .from(from)
+                .size(size)
+                .query(getQueryBuilder(request)));
 
             return searchRequest;
         } catch (final Exception e) {
@@ -37,28 +33,30 @@ public final class SearchUtil {
         }
     }
 
-    private static QueryBuilder getQueryBuilder(final AuditSearchRequest request) {
+    private static Query getQueryBuilder(final AuditSearchRequest request) {
         Map<String, String> fields = request.getFilters();
         if (CollectionUtils.isEmpty(fields)) {
             return null;
         }
-        Optional<String> firstKey = fields.keySet().stream().findFirst();
-        if (firstKey.isPresent()) {
-            BoolQueryBuilder queryBuilder = QueryBuilders.boolQuery();
-            for (Entry<String, String> entry : fields.entrySet()) {
-                if (request.getAction().equalsIgnoreCase(Constants.AUDIT_NOTIFICATION_SEARCH) && entry.getKey().equalsIgnoreCase(Constants.HCX_SENDER_CODE)){
-                    queryBuilder = queryBuilder.should(QueryBuilders.termQuery(Constants.HCX_SENDER_CODE, entry.getValue()));
-                    queryBuilder = queryBuilder.should(QueryBuilders.termQuery(Constants.HCX_RECIPIENT_CODE, entry.getValue()));
-                } else if(!entry.getKey().equalsIgnoreCase(Constants.START_DATETIME) && !entry.getKey().equalsIgnoreCase(Constants.STOP_DATETIME)) {
-                	queryBuilder = queryBuilder.must(QueryBuilders.matchPhraseQuery(entry.getKey(),entry.getValue()));
-                } else if (entry.getKey().equalsIgnoreCase(Constants.START_DATETIME)) {
-                	queryBuilder = queryBuilder.must(QueryBuilders.rangeQuery(Constants.TIMESTAMP).gte(entry.getValue()));
-                } else if (entry.getKey().equalsIgnoreCase(Constants.STOP_DATETIME)) {
-                	queryBuilder = queryBuilder.must(QueryBuilders.rangeQuery(Constants.TIMESTAMP).lte(entry.getValue()));
-                }
+        BoolQuery.Builder queryBuilder = QueryBuilders.bool();
+        for (Entry<String, String> entry : fields.entrySet()) {
+            if (request.getAction().equalsIgnoreCase(Constants.AUDIT_NOTIFICATION_SEARCH) && entry.getKey().equalsIgnoreCase(Constants.HCX_SENDER_CODE)) {
+                queryBuilder.should(QueryBuilders.term(t -> t.field(Constants.HCX_SENDER_CODE).value(entry.getValue())));
+                queryBuilder.should(QueryBuilders.term(t -> t.field(Constants.HCX_RECIPIENT_CODE).value(entry.getValue())));
+            } else if (!entry.getKey().equalsIgnoreCase(Constants.START_DATETIME) && !entry.getKey().equalsIgnoreCase(Constants.STOP_DATETIME)) {
+                queryBuilder.must(QueryBuilders.matchPhrase(t -> t.field(entry.getKey()).query(entry.getValue())));
+            } else if (entry.getKey().equalsIgnoreCase(Constants.START_DATETIME)) {
+                queryBuilder.must(QueryBuilders.range(r -> 
+                    r.untyped(nf -> nf
+                        .field(Constants.TIMESTAMP)
+                        .gte(JsonData.of(entry.getValue()))))); // Use gte instead of from
+            } else if (entry.getKey().equalsIgnoreCase(Constants.STOP_DATETIME)) {
+                queryBuilder.must(QueryBuilders.range(r -> 
+                    r.untyped(nf -> nf
+                        .field(Constants.TIMESTAMP)
+                        .lte(JsonData.of(entry.getValue()))))); // Use lte instead of to
             }
-            return queryBuilder;
         }
-        return null;
+        return Query.of(q -> q.bool(queryBuilder.build()));
     }
 }

--- a/hcx-apis/src/test/java/org/swasth/hcx/controllers/BaseSpec.java
+++ b/hcx-apis/src/test/java/org/swasth/hcx/controllers/BaseSpec.java
@@ -1,7 +1,7 @@
 package org.swasth.hcx.controllers;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import org.elasticsearch.client.RestHighLevelClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -82,7 +82,7 @@ public class BaseSpec {
     protected RegistryService mockRegistryService;
 
     @MockBean
-    protected RestHighLevelClient restHighLevelClient;
+    protected ElasticsearchClient elasticsearchClient;
 
     @MockBean
     protected JWTUtils jwtUtils;

--- a/hcx-apis/src/test/java/org/swasth/hcx/controllers/v1/AuditControllerTests.java
+++ b/hcx-apis/src/test/java/org/swasth/hcx/controllers/v1/AuditControllerTests.java
@@ -1,7 +1,6 @@
 package org.swasth.hcx.controllers.v1;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import org.elasticsearch.client.RestHighLevelClient;
+import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,7 +44,7 @@ class AuditControllerTests {
     private AuditService auditService;
 
     @MockBean
-    private RestHighLevelClient restHighLevelClient;
+    private ElasticsearchClient elasticsearchClient;
 
     @BeforeEach
     public void setup() {

--- a/hcx-apis/src/test/java/org/swasth/hcx/utils/SearchUtilsTests.java
+++ b/hcx-apis/src/test/java/org/swasth/hcx/utils/SearchUtilsTests.java
@@ -1,6 +1,6 @@
 package org.swasth.hcx.utils;
 
-import org.elasticsearch.action.search.SearchRequest;
+import co.elastic.clients.elasticsearch.core.SearchRequest;
 import org.junit.jupiter.api.Test;
 import org.springframework.test.context.ContextConfiguration;
 import org.swasth.common.dto.AuditSearchRequest;
@@ -30,7 +30,7 @@ class SearchUtilsTests extends BaseSpec {
         }});
         searchRequest.setAction(Constants.AUDIT_SEARCH);
         SearchRequest result = SearchUtil.buildSearchRequest("hcx_audit",searchRequest);
-        assertEquals("hcx_audit", result.indices()[0]);
+        assertEquals("hcx_audit", result.index().get(0));
     }
 
     @Test

--- a/hcx-core/audit-indexer/pom.xml
+++ b/hcx-core/audit-indexer/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.14.0</version>
+            <version>2.14.2</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>

--- a/hcx-core/audit-indexer/pom.xml
+++ b/hcx-core/audit-indexer/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.12.5</version>
+            <version>2.14.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.commons</groupId>
@@ -24,9 +24,9 @@
             <version>3.12.0</version>
         </dependency>
         <dependency>
-            <groupId>org.elasticsearch.client</groupId>
-            <artifactId>elasticsearch-rest-high-level-client</artifactId>
-            <version>7.12.1</version>
+            <groupId>co.elastic.clients</groupId>
+            <artifactId>elasticsearch-java</artifactId>
+            <version>8.17.0</version>
         </dependency>
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>

--- a/hcx-core/audit-indexer/src/main/java/org/swasth/auditindexer/utils/ElasticSearchUtil.java
+++ b/hcx-core/audit-indexer/src/main/java/org/swasth/auditindexer/utils/ElasticSearchUtil.java
@@ -2,26 +2,18 @@ package org.swasth.auditindexer.utils;
 
 import co.elastic.clients.elasticsearch.ElasticsearchClient;
 import co.elastic.clients.elasticsearch._types.mapping.TypeMapping;
+import co.elastic.clients.elasticsearch.cluster.HealthResponse;
 import co.elastic.clients.elasticsearch.core.IndexRequest;
-import co.elastic.clients.elasticsearch.indices.Alias;
 import co.elastic.clients.elasticsearch.indices.CreateIndexRequest;
 import co.elastic.clients.elasticsearch.indices.ExistsRequest;
-import co.elastic.clients.elasticsearch.indices.GetIndexRequest;
-import co.elastic.clients.elasticsearch.transform.Settings;
 import co.elastic.clients.transport.rest_client.RestClientTransport;
 import co.elastic.clients.json.jackson.JacksonJsonpMapper;
 import org.apache.http.HttpHost;
-import org.apache.http.util.EntityUtils;
-import org.elasticsearch.client.Request;
-import org.elasticsearch.client.RequestOptions;
-import org.elasticsearch.client.Response;
 import org.elasticsearch.client.RestClient;
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.UUID;
 
 public class ElasticSearchUtil {
 
@@ -103,6 +95,17 @@ public class ElasticSearchUtil {
             } catch (IOException e) {
                 throw new Exception("ElasticSearchUtil :: Error while closing RestClient connection : " + e.getMessage());
             }
+        }
+    }
+
+    public boolean isHealthy() {
+        try {
+            HealthResponse response = esClient.cluster().health();
+            String status = response.status().jsonValue();
+            return "green".equals(status) || "yellow".equals(status);
+        } catch (Exception e) {
+            e.printStackTrace();
+            return false;
         }
     }
 }


### PR DESCRIPTION
### Summary
This PR updates the ElasticSearch client to version 8.17 to ensure compatibility with the latest features and improvements.


### Notes:
- Ensure the ElasticSearch server is updated to version 8.17 before deploying these changes.
- Update any dependent services or configurations to align with the new ElasticSearch version.