### PR TITLE
Fix: Removed unnecessary space in getUserRequest method

### DIFF
--- a/hcx-apis/src/main/java/org/swasth/hcx/service/UserService.java
+++ b/hcx-apis/src/main/java/org/swasth/hcx/service/UserService.java
@@ -151,7 +151,7 @@ public class UserService extends BaseRegistryService {
     }
 
     private String getUserRequest(String userId) {
-        return "{ \"filters\": { \"user_id\": { \"eq\": \" " + userId + "\" } } }";
+        return "{ \"filters\": { \"user_id\": { \"eq\": \"" + userId + "\" } } }";
     }
 
     private void generateUserAudit(String userId, String action, Map<String, Object> requestBody, String updatedBy) throws Exception {


### PR DESCRIPTION
This PR addresses a minor bug in the getUserRequest method of the UserService class. The issue was caused by an unnecessary space in the JSON string construction, which could potentially lead to inconsistencies in user search operations. The fix ensures the JSON string is properly formatted without extra spaces.